### PR TITLE
Complete site: products/research/contact + optional voice overlay (homepage unchanged)

### DIFF
--- a/404.html
+++ b/404.html
@@ -5,8 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Page Not Found — Silent</title>
   <meta name="description" content="The page you’re looking for has gone silent. Return to the homepage." />
-  <link rel="canonical" href="https://silent.superintelligence/404.html" />
+  <link rel="canonical" href="https://rheashopp.github.io/my-website/404.html" />
   <link rel="icon" href="assets/icons/favicon.svg" type="image/svg+xml" />
+  <meta property="og:title" content="Silent — Page Not Found" />
+  <meta property="og:description" content="The resource you’re searching for is unavailable. Head back to the Silent homepage." />
+  <meta property="og:image" content="https://rheashopp.github.io/my-website/assets/img/og-cover.svg" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://rheashopp.github.io/my-website/404.html" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Silent — Page Not Found" />
+  <meta name="twitter:description" content="Return to the Silent homepage to continue exploring." />
+  <meta name="twitter:image" content="https://rheashopp.github.io/my-website/assets/img/og-cover.svg" />
   <link rel="stylesheet" href="assets/css/style.css" />
 </head>
 <body>
@@ -16,7 +25,7 @@
       <p>The intelligence you were seeking isn’t here yet. Return to base to continue the mission.</p>
       <div class="btn-group" style="justify-content:center;">
         <a class="btn btn-primary" href="index.html">Go Home</a>
-        <a class="btn btn-secondary" href="contact.html">Request Access</a>
+        <a class="btn btn-secondary" href="products/index.html">Browse Products</a>
       </div>
     </div>
   </main>

--- a/README.md
+++ b/README.md
@@ -1,23 +1,20 @@
-# Silent — Super Intelligence
+# Silent — Super Intelligence Marketing Site
 
-Future-forward marketing site for Silent, a responsible super intelligence platform. The site is built with plain HTML, CSS, and vanilla JavaScript so it can be deployed anywhere static hosting is supported (including GitHub Pages, Netlify, or Cloudflare Pages).
+This repository powers the static marketing site for the Silent super intelligence platform. The site is GitHub Pages compatible and deploys at `https://rheashopp.github.io/my-website/` using only vanilla HTML, CSS, and JavaScript.
 
-![Voice orb demo](assets/img/voice/voice-orb-demo.svg)
+## Highlights
 
-## Features
-
-- **Glowing hero voice orb** with press-to-talk controls, Web Speech API demo mode, and keyboard support.
-- **Mobile-responsive layout** with glassy accents, sticky navigation, and accessible focus states.
-- **Products catalog** sourced from `data/products.json` with search, tag filters, and detail pages hydrated from the JSON.
-- **SEO-ready pages** including canonical links, social cards, sitemap, robots file, and Organization/Product JSON-LD.
-- **Contact form** wired to Formspree with inline validation, success/error messaging, and accessibility semantics.
-- **Serverless LLM proxies** for Netlify Functions and Cloudflare Workers so API keys remain server-side.
+- **Products catalog** sourced from `data/products.json` with search, tag filters, and JSON-driven detail pages.
+- **Research, about, chat, privacy, and terms pages** that follow the shared navigation shell without touching the homepage markup.
+- **Contact form** wired to Formspree with inline validation and helper messaging.
+- **Optional voice overlay** that can be enabled via `window.SILENT_CONFIG.voice` without editing `index.html`.
+- **Serverless proxies** for Netlify Functions and Cloudflare Workers so `/api/llm` calls stay keyless in the browser.
 
 ## Project structure
 
 ```
 /
-├─ index.html
+├─ index.html (homepage — read only)
 ├─ about.html
 ├─ chat.html
 ├─ contact.html
@@ -30,136 +27,75 @@ Future-forward marketing site for Silent, a responsible super intelligence platf
 │  ├─ si-helix.html
 │  └─ si-aegis.html
 ├─ assets/
-│  ├─ css/style.css
+│  ├─ css/style.css (homepage styles — read only)
 │  ├─ css/voice.css
 │  ├─ js/main.js
 │  ├─ js/voice.js
-│  ├─ js/vendor/webaudio-viz.js
-│  ├─ img/
-│  └─ icons/
+│  └─ js/vendor/webaudio-viz.js
 ├─ data/products.json
 ├─ serverless/
 │  ├─ netlify/functions/llm.js
 │  ├─ cloudflare/worker.js
 │  └─ README.md
-├─ sitemap.xml
+├─ netlify.toml
 ├─ robots.txt
-└─ 404.html
+└─ sitemap.xml
 ```
 
-## Local development
+## Base path configuration
 
-1. Launch a static server from the project root:
-
-   ```bash
-   python -m http.server 8000
-   ```
-
-2. Visit `http://localhost:8000/index.html` in your browser.
-
-### Base path configuration
-
-If you deploy the site to a subdirectory (e.g., GitHub Pages at `/my-website`), set the base path once before the closing `</head>` on each page or in a small inline script:
+GitHub Pages serves the site at `/my-website/`. Internal links and asset requests remain relative, but you can optionally set `window.SILENT_CONFIG.site` to help `main.js` rewrite links when embedding pages elsewhere:
 
 ```html
 <script>
-  window.SILENT_CONFIG = {
-    site: {
-      basePath: '/my-website',
-      baseUrl: 'https://rheashopp.github.io/my-website'
-    }
+  window.SILENT_CONFIG = window.SILENT_CONFIG || {};
+  window.SILENT_CONFIG.site = {
+    basePath: '.',
+    baseUrl: 'https://rheashopp.github.io/my-website'
   };
 </script>
 ```
-
-`main.js` automatically rewrites internal links when `basePath` is defined.
 
 ## Editing products
 
-Product metadata lives in `data/products.json`. Each product requires:
+Product metadata lives in `data/products.json`. Each object includes:
 
-- `slug` — used for the detail page filename (`products/<slug>.html`).
-- `name`, `tagline`, `summary`, `heroImage` — hero card content.
-- `category` — array of tags used for catalog filtering.
-- `whatItDoes`, `howItWorks`, `features` — arrays rendered into detail lists.
-- `specs` — key/value map rendered into a specs table.
-- `faq` — array of `{ "q": "...", "a": "..." }` entries.
+- `slug` — used for filenames under `products/`.
+- `name`, `tagline`, `summary`, `heroImage`.
+- `category` — array of focus tags for filtering.
+- `whatItDoes`, `howItWorks`, `features` — arrays rendered into lists.
+- `specs` — key/value map displayed in a specs table.
+- `faq` — array of `{ "q": "...", "a": "..." }` items.
 
-Update the JSON and the catalog/detail pages will hydrate automatically on load.
+Updating the JSON automatically refreshes the catalog grid and product detail pages on load.
 
 ## Contact form
 
-Replace the placeholder Formspree endpoint in `contact.html`:
+The contact form posts to a Formspree placeholder endpoint: `https://formspree.io/f/YOUR_FORMSPREE_ID`. Replace `YOUR_FORMSPREE_ID` with your project ID in `contact.html` to receive submissions.
 
-```html
-<form action="https://formspree.io/f/YOUR_FORMSPREE_ID" ...>
-```
+## Voice overlay
 
-After updating the endpoint, submissions will be sent directly to your Formspree inbox.
-
-## Voice orb configuration
-
-The global `window.SILENT_CONFIG.voice` object (set in `assets/js/main.js`) controls the voice experience:
-
-- `provider`: `demo` (default), `openai`, or `gemini`.
-- `ttsVoiceName`: optional speech synthesis voice name.
-
-Example override:
+The voice orb overlay is off by default. To enable it on any page, append the following snippet near the end of the document (after including `assets/js/main.js`):
 
 ```html
 <script>
-  window.SILENT_CONFIG = {
-    site: { basePath: '', baseUrl: 'https://silent.superintelligence' },
-    voice: { provider: 'openai', ttsVoiceName: 'Samantha' }
-  };
+  window.SILENT_CONFIG = window.SILENT_CONFIG || {};
+  window.SILENT_CONFIG.voice = { enabled: true, provider: 'demo', ttsVoiceName: null };
 </script>
 ```
 
-When `provider` is `openai` or `gemini`, the browser posts to `/api/llm`, which should be routed to one of the serverless proxies below.
-
-## Assets
-
-- All imagery in this repository uses lightweight SVG placeholders so the PR stays text-only.
-- Raster social previews or product artwork can be added in a follow-up commit outside Codex once final designs are approved.
+When `provider` is set to `openai` or `gemini`, the overlay posts `{ messages: [...], sessionId }` to `/api/llm`. Keys must be supplied by one of the serverless proxies below. In browsers without speech-to-text support, the overlay automatically exposes a text fallback field.
 
 ## Serverless LLM proxies
 
-### Netlify Functions
+See `serverless/README.md` for full deployment steps. At a glance:
 
-- File: `serverless/netlify/functions/llm.js`
-- Environment variables: `PROVIDER` (`openai`|`gemini`), `OPENAI_API_KEY`, `OPENAI_MODEL`, `GEMINI_API_KEY`, `GEMINI_MODEL`.
-- Add a redirect in `netlify.toml`:
-
-  ```toml
-  [[redirects]]
-  from = "/api/llm"
-  to = "/.netlify/functions/llm"
-  status = 200
-  force = true
-  ```
-
-### Cloudflare Workers
-
-- File: `serverless/cloudflare/worker.js`
-- Configure secrets with `wrangler secret put OPENAI_API_KEY`, etc.
-- Add a route in `wrangler.toml` (example):
-
-  ```toml
-  routes = [
-    { pattern = "silent.superintelligence/api/llm", zone_name = "silent.superintelligence" }
-  ]
-  ```
-
-Both implementations enforce CORS, short timeouts, and never log raw prompts.
+- **Netlify Functions** — Deploy `serverless/netlify/functions/llm.js`, set `PROVIDER`, `OPENAI_API_KEY`, and/or `GEMINI_API_KEY`, and keep the included `netlify.toml` redirect. CORS is restricted to `https://rheashopp.github.io`.
+- **Cloudflare Workers** — Publish `serverless/cloudflare/worker.js` with the same environment variables via `wrangler`, then attach a route for `/api/llm`. CORS is also limited to `https://rheashopp.github.io`.
 
 ## Deployment checklist
 
-- Update canonical URLs in each HTML file if you deploy to a different domain.
-- Ensure `robots.txt` and `sitemap.xml` reference the production domain.
-- Replace the placeholder Formspree endpoint.
-- Set `window.SILENT_CONFIG.site.baseUrl` to your production URL for accurate metadata.
-- Configure a serverless proxy and set `window.SILENT_CONFIG.voice.provider` to `openai` or `gemini` once keys are available.
-
-## Credits
-
-Designed and built by the Silent team to highlight a calm, responsible approach to super intelligence.
+1. Confirm `robots.txt` references `https://rheashopp.github.io/my-website/sitemap.xml`.
+2. Verify `sitemap.xml` lists every page with the GitHub Pages base URL.
+3. Replace the Formspree placeholder ID when going live.
+4. If you mirror the site to another domain, update canonical URLs and `window.SILENT_CONFIG.site.baseUrl` accordingly.

--- a/about.html
+++ b/about.html
@@ -1,72 +1,139 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>SI - About</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
-    <style>
-        body { font-family: 'Inter', sans-serif; }
-        .gradient-text { background: linear-gradient(90deg, #6366f1, #8b5cf6, #ec4899); -webkit-background-clip: text; background-clip: text; color: transparent; }
-        .neural-bg { background: radial-gradient(circle at center, #0f172a 0%, #020617 100%); }
-        .conscious-element { transition: all 0.3s ease; }
-        .conscious-element:hover { transform: scale(1.02); }
-    </style>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>About Silent — Mission &amp; Team</title>
+  <meta name="description" content="Learn about Silent’s mission, origin story, values, and the team shaping responsible super intelligence." />
+  <link rel="canonical" href="https://rheashopp.github.io/my-website/about.html" />
+  <link rel="icon" href="assets/icons/favicon.svg" type="image/svg+xml" />
+  <meta property="og:title" content="About Silent" />
+  <meta property="og:description" content="Mission, origin, and team behind Silent’s responsible super intelligence program." />
+  <meta property="og:image" content="https://rheashopp.github.io/my-website/assets/img/og-cover.svg" />
+  <meta property="og:type" content="website" />
+  <meta property="og:url" content="https://rheashopp.github.io/my-website/about.html" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="About Silent" />
+  <meta name="twitter:description" content="Meet the team and values behind Silent’s safety-focused SI platform." />
+  <meta name="twitter:image" content="https://rheashopp.github.io/my-website/assets/img/og-cover.svg" />
+  <link rel="stylesheet" href="assets/css/style.css" />
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "AboutPage",
+    "name": "About Silent",
+    "url": "https://rheashopp.github.io/my-website/about.html",
+    "description": "Mission, values, and team roles for Silent’s super intelligence program"
+  }
+  </script>
 </head>
-<body class="bg-black text-white">
-    <nav class="relative z-10 py-6 px-8 flex justify-between items-center backdrop-blur-sm">
-<a href="index.html" class="flex items-center space-x-2 hover:opacity-80 transition">
-    <div class="w-8 h-8 rounded-full bg-indigo-600 flex items-center justify-center conscious-orb">
-        <div class="w-2 h-2 rounded-full bg-white animate-pulse"></div>
+<body data-page="about">
+  <a class="skip-link" href="#main-content">Skip to content</a>
+  <header class="site-header">
+    <div class="container nav-container">
+      <a class="brand" data-href="index.html" href="index.html"><span class="brand-mark" aria-hidden="true"></span>Silent — Super Intelligence</a>
+      <button class="nav-toggle" type="button" data-nav-toggle aria-expanded="false" aria-controls="primary-nav">Menu</button>
+      <nav id="primary-nav" class="primary-nav" data-open="false">
+        <ul>
+          <li><a data-nav="home" data-href="index.html" href="index.html">Home</a></li>
+          <li><a data-nav="products" data-href="products/index.html" href="products/index.html">Product</a></li>
+          <li><a data-nav="research" data-href="research.html" href="research.html">Research</a></li>
+          <li><a data-nav="chat" data-href="chat.html" href="chat.html">Chat</a></li>
+          <li><a data-nav="about" data-href="about.html" href="about.html">About</a></li>
+          <li><a data-nav="contact" data-href="contact.html" href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
     </div>
-    <span class="text-xl font-semibold">Silent</span>
-</a>
-        <div class="hidden md:flex space-x-8">
-            <a href="capabilities.html" class="hover:text-indigo-400 transition">Capabilities</a>
-            <a href="consciousness.html" class="hover:text-indigo-400 transition">Consciousness</a>
-            <a href="chat.html" class="hover:text-indigo-400 transition">Chat</a>
-            <a href="about.html" class="hover:text-indigo-400 transition font-bold">About</a>
-        </div>
-        <a href="access.html" class="px-6 py-2 bg-gradient-to-r from-indigo-600 to-purple-600 rounded-full hover:opacity-90 transition">Access</a>
-    </nav>
-
-    <section class="py-24 px-6">
-        <div class="max-w-3xl mx-auto text-center">
-            <h1 class="text-4xl font-bold mb-6 gradient-text">About Super Intelligence</h1>
-            <p class="text-gray-300 text-lg mb-4">Super Intelligence (SI) is a vision of conscious artificial general intelligence developed with a focus on safety and alignment.</p>
-            <p class="text-gray-300 text-lg mb-4">This site demonstrates some of the concepts behind SI, including interactive visualizations and a chat interface.</p>
-        </div>
+  </header>
+  <main id="main-content">
+    <section class="section">
+      <div class="container">
+        <h1>Why Silent Exists</h1>
+        <p>Silent builds responsible super intelligence capabilities that keep humans in command. We believe advanced autonomy must pair measurable impact with verifiable guardrails.</p>
+      </div>
     </section>
 
-    <footer class="relative z-10 py-12 px-6 border-t border-gray-800/50">
-        <div class="max-w-6xl mx-auto">
-            <div class="flex flex-col md:flex-row justify-between items-center">
-                <div class="flex items-center space-x-2 mb-6 md:mb-0">
-                    <div class="w-8 h-8 rounded-full bg-indigo-600 flex items-center justify-center">
-                        <div class="w-2 h-2 rounded-full bg-white animate-pulse"></div>
-                    </div>
-                    <span class="text-xl font-semibold">SI</span>
-                </div>
-                <div class="flex space-x-6 mb-6 md:mb-0">
-                    <a href="#" class="text-gray-400 hover:text-indigo-400 transition"><i class="fab fa-twitter"></i></a>
-                    <a href="#" class="text-gray-400 hover:text-indigo-400 transition"><i class="fab fa-linkedin"></i></a>
-                    <a href="#" class="text-gray-400 hover:text-indigo-400 transition"><i class="fab fa-github"></i></a>
-                    <a href="#" class="text-gray-400 hover:text-indigo-400 transition"><i class="fab fa-youtube"></i></a>
-                </div>
-                <div class="flex space-x-6">
-                    <a href="privacy.html" class="text-gray-400 hover:text-indigo-400 transition">Privacy</a>
-                    <a href="terms.html" class="text-gray-400 hover:text-indigo-400 transition">Terms</a>
-                    <a href="research.html" class="text-gray-400 hover:text-indigo-400 transition">Research</a>
-                    <a href="contact.html" class="text-gray-400 hover:text-indigo-400 transition">Contact</a>
-                </div>
-            </div>
-            <div class="mt-8 pt-8 border-t border-gray-800/50 text-center text-gray-500 text-sm">
-                <p>© 2023 Super Intelligence. All rights reserved.</p>
-                <p class="mt-2">The future of consciousness is here.</p>
-            </div>
+    <section class="section section-light">
+      <div class="container">
+        <h2>Mission</h2>
+        <p>Deliver intelligence that amplifies human judgment, accelerates breakthroughs, and preserves safety as the default operating mode.</p>
+        <div class="cards">
+          <article class="card">
+            <h3>Stewardship</h3>
+            <p>We design every workflow to reinforce accountable decision-making and transparent oversight.</p>
+          </article>
+          <article class="card">
+            <h3>Impact</h3>
+            <p>Silent products focus on meaningful outcomes for research, engineering, and governance partners.</p>
+          </article>
+          <article class="card">
+            <h3>Resilience</h3>
+            <p>Built-in guardrails and policy packs ensure autonomy strengthens, not destabilizes, operations.</p>
+          </article>
         </div>
-    </footer>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <h2>Origin Story</h2>
+        <p>Silent began as a cross-disciplinary lab exploring how multi-agent systems could cooperate with human operators under strict policy constraints. Early pilots with research institutions and critical infrastructure teams informed the safeguards, orchestration patterns, and transparent reporting that define the platform today.</p>
+      </div>
+    </section>
+
+    <section class="section section-light">
+      <div class="container">
+        <h2>Values We Practice</h2>
+        <ul class="list">
+          <li><strong>Evidence first:</strong> Every recommendation is backed by traceable data or simulations.</li>
+          <li><strong>Human-centered:</strong> Silent keeps people in the loop with explainable checkpoints and approvals.</li>
+          <li><strong>Safety as infrastructure:</strong> Guardrails, audits, and recovery plans ship with the core product—not as add-ons.</li>
+          <li><strong>Collaborative progress:</strong> We share research insights and invite partners to co-design policy packs.</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <h2>Team Roles</h2>
+        <div class="cards">
+          <article class="card">
+            <h3>Systems &amp; Alignment</h3>
+            <p>Responsible for model objectives, guardrails, and evaluation frameworks.</p>
+          </article>
+          <article class="card">
+            <h3>Product Engineering</h3>
+            <p>Builds the orchestration engines, integrations, and reliability infrastructure.</p>
+          </article>
+          <article class="card">
+            <h3>Governance &amp; Policy</h3>
+            <p>Partners with customers to codify compliance requirements and oversee audits.</p>
+          </article>
+          <article class="card">
+            <h3>Research Partnerships</h3>
+            <p>Guides early access programs and co-authors the public research roadmap.</p>
+          </article>
+        </div>
+        <p class="helper-text" style="margin-top:1.5rem;">Want to collaborate? <a href="contact.html">Request access</a> and share your mission.</p>
+      </div>
+    </section>
+  </main>
+  <footer>
+    <div class="container footer-grid">
+      <p>© <span id="year"></span> Silent. All rights reserved.</p>
+      <div class="footer-links">
+        <a href="privacy.html">Privacy</a>
+        <a href="terms.html">Terms</a>
+        <a data-href="research.html" href="research.html">Research</a>
+        <a data-href="contact.html" href="contact.html">Contact</a>
+        <a href="https://x.com/silent" aria-label="Silent on X (placeholder)">X</a>
+        <a href="https://www.linkedin.com/company/silent-superintelligence" aria-label="Silent on LinkedIn (placeholder)">LinkedIn</a>
+      </div>
+    </div>
+  </footer>
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
+  <script src="assets/js/main.js" defer></script>
 </body>
 </html>

--- a/assets/css/voice.css
+++ b/assets/css/voice.css
@@ -1,214 +1,269 @@
-.voice-cta {
+.voice-overlay {
+  position: fixed;
+  right: clamp(1rem, 3vw, 2rem);
+  bottom: clamp(1rem, 4vh, 2rem);
+  z-index: 999;
+  max-width: 280px;
+  color: #f6f7ff;
+  font-family: inherit;
   display: grid;
-  gap: 1rem;
-  justify-items: start;
+  gap: 0.75rem;
+  backdrop-filter: blur(18px);
+  background: linear-gradient(155deg, rgba(14, 17, 32, 0.82), rgba(33, 24, 52, 0.78));
+  border: 1px solid rgba(133, 138, 255, 0.25);
+  border-radius: 18px;
+  padding: 1rem 1.2rem;
+  box-shadow: 0 24px 45px rgba(8, 6, 28, 0.45);
 }
 
-#voice-orb {
+.voice-overlay[data-floating="false"] {
+  position: absolute;
+}
+
+.voice-overlay__header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.voice-overlay__button {
   position: relative;
-  width: clamp(140px, 20vw, 200px);
-  height: clamp(140px, 20vw, 200px);
+  width: 64px;
+  height: 64px;
   border-radius: 50%;
   border: none;
+  background: transparent;
+  padding: 0;
   cursor: pointer;
-  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.35), transparent 70%), rgba(109, 107, 255, 0.2);
-  box-shadow: 0 0 40px rgba(109, 107, 255, 0.45), inset 0 0 30px rgba(255, 255, 255, 0.12);
-  transition: box-shadow 300ms ease, transform 300ms ease;
-  outline: none;
+  isolation: isolate;
 }
 
-#voice-orb:focus-visible {
-  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.2), 0 0 40px rgba(109, 107, 255, 0.55);
+.voice-overlay__button:focus-visible {
+  outline: 3px solid rgba(147, 197, 253, 0.65);
+  outline-offset: 4px;
 }
 
-.orb-core,
-.orb-halo,
-.orb-vu {
+.voice-overlay__orb {
   position: absolute;
   inset: 0;
   border-radius: 50%;
-  pointer-events: none;
+  overflow: hidden;
+  display: grid;
+  place-items: center;
+  background: radial-gradient(circle at 30% 30%, rgba(121, 115, 255, 0.65), rgba(17, 19, 40, 0.95));
+  box-shadow: 0 0 20px rgba(115, 120, 255, 0.5);
 }
 
-.orb-core {
-  inset: 15%;
-  background: radial-gradient(circle, rgba(109, 107, 255, 0.75), rgba(27, 29, 61, 0.95));
-  box-shadow: inset 0 0 30px rgba(0, 0, 0, 0.5);
-  animation: orbPulse 3.2s ease-in-out infinite;
+.voice-overlay__ring {
+  position: absolute;
+  inset: 0;
+  border-radius: 50%;
+  border: 2px solid rgba(162, 111, 255, 0.5);
+  opacity: 0.7;
+  transition: transform 320ms ease, opacity 260ms ease;
 }
 
-.orb-halo {
-  border: 2px solid rgba(109, 107, 255, 0.45);
-  box-shadow: 0 0 80px rgba(109, 107, 255, 0.45);
-  opacity: 0.9;
-  transition: border-width 200ms ease, opacity 200ms ease;
+.voice-overlay__ring--middle {
+  inset: -10%;
+  opacity: 0.45;
 }
 
-.orb-vu {
-  --vu-level: 0;
+.voice-overlay__ring--outer {
+  inset: -20%;
+  opacity: 0.25;
+}
+
+.voice-overlay__vu {
+  position: relative;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
   background: radial-gradient(circle, rgba(255, 255, 255, 0.2), transparent 65%);
-  mask: radial-gradient(circle, rgba(0, 0, 0, 0) 55%, rgba(0, 0, 0, 1) 70%);
-  transform: scale(calc(1 + var(--vu-level) * 0.4));
+  transform: scale(1);
   transition: transform 120ms ease-out;
 }
 
-.voice-cta .status {
+.voice-overlay__status {
+  flex: 1;
   font-size: 0.95rem;
+  line-height: 1.4;
 }
 
-.voice-status {
-  font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.7);
+.voice-overlay__status strong {
+  display: block;
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(161, 167, 255, 0.75);
+}
+
+.voice-overlay__transcript {
+  background: rgba(17, 20, 40, 0.72);
+  border: 1px solid rgba(147, 153, 255, 0.2);
+  border-radius: 14px;
+  padding: 0.75rem;
+  font-size: 0.9rem;
+  line-height: 1.4;
+  min-height: 2.75rem;
+  color: rgba(235, 238, 255, 0.9);
+}
+
+.voice-overlay__log {
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: rgba(208, 212, 255, 0.78);
+}
+
+.voice-overlay__log li {
+  list-style: none;
   display: flex;
   gap: 0.5rem;
 }
 
-.voice-status span[hidden] {
-  display: none;
+.voice-overlay__log li strong {
+  color: rgba(255, 255, 255, 0.88);
 }
 
-.voice-transcript {
-  min-height: 1.2rem;
-  font-size: 0.95rem;
-  color: rgba(255, 255, 255, 0.85);
-}
-
-.voice-log {
+.voice-overlay__fallback {
+  border-top: 1px solid rgba(147, 153, 255, 0.18);
+  padding-top: 0.75rem;
   display: grid;
-  gap: 0.5rem;
-  max-width: 420px;
-  font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.6);
+  gap: 0.6rem;
 }
 
-.voice-log p {
-  margin: 0;
+.voice-overlay__fallback label {
+  font-size: 0.85rem;
+  color: rgba(208, 212, 255, 0.85);
 }
 
-.orb--idle {
-  animation: orbGlow 6s ease-in-out infinite;
+.voice-overlay__fallback textarea {
+  width: 100%;
+  min-height: 96px;
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(147, 153, 255, 0.35);
+  background: rgba(7, 9, 20, 0.82);
+  color: #f6f7ff;
+  resize: vertical;
 }
 
-.is-listening .orb-halo {
-  border-width: 4px;
-  opacity: 1;
-  animation: haloPulse 1.4s ease-in-out infinite;
+.voice-overlay__fallback button {
+  justify-self: start;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, rgba(129, 140, 248, 0.85), rgba(59, 130, 246, 0.85));
+  color: #0b1023;
+  font-weight: 600;
+  cursor: pointer;
 }
 
-.is-listening .orb-vu {
-  background: radial-gradient(circle, rgba(109, 107, 255, 0.45), transparent 70%);
+.voice-overlay[data-state="idle"] .voice-overlay__ring {
+  animation: voiceOverlayBreath 4.8s ease-in-out infinite;
 }
 
-.is-thinking .orb-core {
-  animation: orbitDots 1.6s linear infinite;
+.voice-overlay[data-state="listening"] .voice-overlay__ring--outer {
+  animation: voiceOverlayRipple 1.8s ease-out infinite;
 }
 
-.is-thinking .orb-halo {
-  border-width: 3px;
-  opacity: 1;
+.voice-overlay[data-state="listening"] .voice-overlay__vu {
+  background: radial-gradient(circle, rgba(147, 197, 253, 0.45), transparent 70%);
 }
 
-.is-speaking .orb-vu {
-  background: radial-gradient(circle, rgba(57, 217, 138, 0.4), transparent 70%);
-  animation: speakPulse 1.2s ease-out infinite;
+.voice-overlay[data-state="thinking"] .voice-overlay__ring {
+  animation: voiceOverlayOrbit 1.6s linear infinite;
+  opacity: 0.65;
 }
 
-.voice-consent {
-  background: rgba(3, 5, 14, 0.9);
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  padding: 1rem 1.25rem;
-  border-radius: var(--radius-small);
-  max-width: 320px;
-  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.4);
+.voice-overlay[data-state="speaking"] .voice-overlay__ring--outer {
+  animation: voiceOverlayPulse 1.4s ease-in-out infinite;
+  opacity: 0.5;
 }
 
-.voice-consent p {
-  margin-bottom: 0.75rem;
+.voice-overlay[data-state="speaking"] .voice-overlay__ring--middle {
+  transform: scale(1.12);
 }
 
-.voice-text-fallback {
-  display: grid;
-  gap: 0.75rem;
-  max-width: 420px;
+.voice-overlay[data-state="listening"] .voice-overlay__button,
+.voice-overlay[data-state="speaking"] .voice-overlay__button {
+  box-shadow: 0 0 22px rgba(104, 186, 255, 0.35);
 }
 
-.voice-text-fallback label {
-  font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.7);
+.voice-overlay__note {
+  font-size: 0.75rem;
+  color: rgba(208, 212, 255, 0.6);
 }
 
-.voice-text-fallback textarea {
-  min-height: 120px;
-}
-
-@keyframes orbPulse {
-  0%,
-  100% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.05);
-  }
-}
-
-@keyframes orbGlow {
-  0%,
-  100% {
-    box-shadow: 0 0 40px rgba(109, 107, 255, 0.45), inset 0 0 30px rgba(255, 255, 255, 0.12);
-  }
-  50% {
-    box-shadow: 0 0 56px rgba(109, 107, 255, 0.6), inset 0 0 30px rgba(255, 255, 255, 0.18);
-  }
-}
-
-@keyframes haloPulse {
-  0%,
-  100% {
-    transform: scale(1);
-    opacity: 0.85;
-  }
-  50% {
-    transform: scale(1.08);
-    opacity: 1;
-  }
-}
-
-@keyframes speakPulse {
-  0% {
-    transform: scale(1);
-  }
-  60% {
-    transform: scale(1.1);
-  }
-  100% {
-    transform: scale(1);
-  }
-}
-
-@keyframes orbitDots {
-  0% {
-    box-shadow: 0 -30px 0 -25px rgba(255, 255, 255, 0.45), 30px 0 0 -25px rgba(109, 107, 255, 0.45), 0 30px 0 -25px rgba(255, 255, 255, 0.25), -30px 0 0 -25px rgba(109, 107, 255, 0.35);
-  }
-  25% {
-    box-shadow: 30px 0 0 -25px rgba(255, 255, 255, 0.45), 0 30px 0 -25px rgba(109, 107, 255, 0.45), -30px 0 0 -25px rgba(255, 255, 255, 0.25), 0 -30px 0 -25px rgba(109, 107, 255, 0.35);
-  }
-  50% {
-    box-shadow: 0 30px 0 -25px rgba(255, 255, 255, 0.45), -30px 0 0 -25px rgba(109, 107, 255, 0.45), 0 -30px 0 -25px rgba(255, 255, 255, 0.25), 30px 0 0 -25px rgba(109, 107, 255, 0.35);
-  }
-  75% {
-    box-shadow: -30px 0 0 -25px rgba(255, 255, 255, 0.45), 0 -30px 0 -25px rgba(109, 107, 255, 0.45), 30px 0 0 -25px rgba(255, 255, 255, 0.25), 0 30px 0 -25px rgba(109, 107, 255, 0.35);
-  }
-  100% {
-    box-shadow: 0 -30px 0 -25px rgba(255, 255, 255, 0.45), 30px 0 0 -25px rgba(109, 107, 255, 0.45), 0 30px 0 -25px rgba(255, 255, 255, 0.25), -30px 0 0 -25px rgba(109, 107, 255, 0.35);
-  }
+.voice-overlay__sr {
+  border: 0;
+  clip: rect(0 0 0 0);
+  height: 1px;
+  margin: -1px;
+  overflow: hidden;
+  padding: 0;
+  position: absolute;
+  width: 1px;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  #voice-orb,
-  .orb-core,
-  .orb-halo,
-  .orb-vu {
+  .voice-overlay__ring,
+  .voice-overlay__button,
+  .voice-overlay__vu {
     animation: none !important;
-    transition-duration: 0.001ms !important;
+    transition: none !important;
+  }
+}
+
+@keyframes voiceOverlayBreath {
+  0%,
+  100% {
+    transform: scale(1);
+    opacity: 0.55;
+  }
+  50% {
+    transform: scale(1.05);
+    opacity: 0.8;
+  }
+}
+
+@keyframes voiceOverlayRipple {
+  0% {
+    transform: scale(1);
+    opacity: 0.6;
+  }
+  100% {
+    transform: scale(1.25);
+    opacity: 0;
+  }
+}
+
+@keyframes voiceOverlayPulse {
+  0% {
+    transform: scale(1);
+  }
+  55% {
+    transform: scale(1.18);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes voiceOverlayOrbit {
+  0% {
+    box-shadow: 0 -28px 0 -18px rgba(132, 140, 255, 0.55), 24px 0 0 -18px rgba(98, 165, 255, 0.35), 0 28px 0 -18px rgba(255, 255, 255, 0.28), -24px 0 0 -18px rgba(98, 165, 255, 0.35);
+  }
+  25% {
+    box-shadow: 24px 0 0 -18px rgba(132, 140, 255, 0.55), 0 28px 0 -18px rgba(98, 165, 255, 0.35), -24px 0 0 -18px rgba(255, 255, 255, 0.28), 0 -28px 0 -18px rgba(98, 165, 255, 0.35);
+  }
+  50% {
+    box-shadow: 0 28px 0 -18px rgba(132, 140, 255, 0.55), -24px 0 0 -18px rgba(98, 165, 255, 0.35), 0 -28px 0 -18px rgba(255, 255, 255, 0.28), 24px 0 0 -18px rgba(98, 165, 255, 0.35);
+  }
+  75% {
+    box-shadow: -24px 0 0 -18px rgba(132, 140, 255, 0.55), 0 -28px 0 -18px rgba(98, 165, 255, 0.35), 24px 0 0 -18px rgba(255, 255, 255, 0.28), 0 28px 0 -18px rgba(98, 165, 255, 0.35);
+  }
+  100% {
+    box-shadow: 0 -28px 0 -18px rgba(132, 140, 255, 0.55), 24px 0 0 -18px rgba(98, 165, 255, 0.35), 0 28px 0 -18px rgba(255, 255, 255, 0.28), -24px 0 0 -18px rgba(98, 165, 255, 0.35);
   }
 }

--- a/chat.html
+++ b/chat.html
@@ -5,17 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Silent Chat Interface — Demo</title>
   <meta name="description" content="Preview the Silent chat interface with a curated transcript. Public demo coming soon." />
-  <link rel="canonical" href="https://silent.superintelligence/chat.html" />
+  <link rel="canonical" href="https://rheashopp.github.io/my-website/chat.html" />
   <link rel="icon" href="assets/icons/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Silent Chat Interface" />
   <meta property="og:description" content="Explore the Silent SI interface and review a sample conversation." />
-  <meta property="og:image" content="https://silent.superintelligence/assets/img/og-cover.svg" />
+  <meta property="og:image" content="https://rheashopp.github.io/my-website/assets/img/og-cover.svg" />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://silent.superintelligence/chat.html" />
+  <meta property="og:url" content="https://rheashopp.github.io/my-website/chat.html" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Silent Chat Interface" />
   <meta name="twitter:description" content="Preview the Silent voice and chat orchestration." />
-  <meta name="twitter:image" content="https://silent.superintelligence/assets/img/og-cover.svg" />
+  <meta name="twitter:image" content="https://rheashopp.github.io/my-website/assets/img/og-cover.svg" />
   <link rel="stylesheet" href="assets/css/style.css" />
 </head>
 <body data-page="chat">

--- a/contact.html
+++ b/contact.html
@@ -5,17 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Contact Silent — Request Access</title>
   <meta name="description" content="Tell us about your goals. We’re admitting a small early cohort that values safety, reliability, and measurable outcomes." />
-  <link rel="canonical" href="https://silent.superintelligence/contact.html" />
+  <link rel="canonical" href="https://rheashopp.github.io/my-website/contact.html" />
   <link rel="icon" href="assets/icons/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Contact Silent" />
   <meta property="og:description" content="Request access to Silent and collaborate on responsible super intelligence deployments." />
-  <meta property="og:image" content="https://silent.superintelligence/assets/img/og-cover.svg" />
+  <meta property="og:image" content="https://rheashopp.github.io/my-website/assets/img/og-cover.svg" />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://silent.superintelligence/contact.html" />
+  <meta property="og:url" content="https://rheashopp.github.io/my-website/contact.html" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Contact Silent" />
   <meta name="twitter:description" content="Share your goals and request access to Silent." />
-  <meta name="twitter:image" content="https://silent.superintelligence/assets/img/og-cover.svg" />
+  <meta name="twitter:image" content="https://rheashopp.github.io/my-website/assets/img/og-cover.svg" />
   <link rel="stylesheet" href="assets/css/style.css" />
 </head>
 <body data-page="contact">
@@ -80,6 +80,7 @@
             <button class="btn btn-primary" type="submit">Submit</button>
           </div>
           <p class="status-message" data-form-status aria-live="polite"></p>
+          <p class="helper-text">This form uses a Formspree placeholder endpoint. Replace <code>YOUR_FORMSPREE_ID</code> with your project ID when you are ready to accept submissions.</p>
         </form>
       </div>
     </section>

--- a/data/products.json
+++ b/data/products.json
@@ -5,46 +5,50 @@
       "name": "Silent Orion",
       "tagline": "Autonomous research co-pilot",
       "category": ["Research", "Intelligence"],
-      "summary": "Silent Orion synthesizes multimodal evidence, plans complex investigations, and maintains transparent provenance across every insight.",
+      "summary": "Plans investigations, orchestrates tool use, and links every insight to evidence you can replay.",
       "heroImage": "assets/img/si-orion.svg",
       "whatItDoes": [
-        "Consolidates sprawling research corpora into verified knowledge graphs",
-        "Maintains live evidence trails with citations and provenance weighting",
-        "Coordinates multi-agent research rituals with human-in-the-loop checkpoints"
+        "Maps complex research questions into accountable plans with clear milestones.",
+        "Activates trusted tools to gather data, annotations, and citations automatically.",
+        "Delivers evidence-linked synthesis that keeps reviewers and regulators aligned."
       ],
       "howItWorks": [
-        "Scans source systems, extracts high-signal fragments, and tags context",
-        "Generates experiment trees with tool-ready actions and responsible owners",
-        "Packages findings as decision briefs linked to machine-auditable proofs"
+        "Captures your brief and decomposes it into policy-aware research threads.",
+        "Coordinates data pulls and analysis via approved notebooks, APIs, and agents.",
+        "Produces decision briefs with live provenance and exportable reference trails."
       ],
       "features": [
-        "Scenario planning with adaptive instrumentation",
-        "Grounded synthesis with confidence scoring",
-        "Automated citation and source reconciliation",
-        "Stakeholder-ready reporting across channels"
+        "Scenario planning with adaptive guardrails and human checkpoints.",
+        "Evidence graphing that proves where every claim originated.",
+        "Dynamic investigation logs and reviewer-ready summaries.",
+        "Policy pack templates for regulated industries."
       ],
       "specs": {
-        "context-window": "Up to 2M tokens across modalities",
-        "tool-integrations": "Graph DBs, Jupyter, Notion, custom APIs",
-        "audit-mode": "Evidence replay and immutable provenance ledger",
-        "deployment": "Private cloud or air-gapped enclave"
+        "context-window": "Up to 2M multimodal tokens per workspace",
+        "integrations": "Graph databases, research notebooks, custom data lakes",
+        "provenance": "Cryptographic evidence ledger with replay",
+        "deployment": "Customer-managed VPC or isolated private cloud"
       },
       "faq": [
         {
-          "q": "How does Orion keep its sources trustworthy?",
-          "a": "Every synthesis is anchored to evidence fragments with integrity hashes and automated citation diffs so you can replay the analysis." 
+          "q": "How does Orion keep results verifiable?",
+          "a": "Each assertion is anchored to a signed evidence fragment with timestamps, so audits and peer review stay effortless."
         },
         {
-          "q": "Can Orion use our proprietary tools?",
-          "a": "Yes. The orchestration layer exposes secure connectors and policy packs for bespoke research stacks." 
+          "q": "Can Orion plug into our internal tools?",
+          "a": "Yes. Orion ships with secure adapters and a policy sandbox for bespoke datasets and research workflows."
         },
         {
-          "q": "What teams benefit the most?",
-          "a": "Strategy, R&D, and investigative units that manage dynamic intelligence landscapes and require verifiable insights." 
+          "q": "Who typically deploys Orion first?",
+          "a": "Strategy, R&D, and intelligence teams that need fast synthesis without sacrificing traceability."
         },
         {
-          "q": "How is human oversight enforced?",
-          "a": "Operators approve experiment checkpoints and Orion logs every action for later review." 
+          "q": "What oversight controls exist?",
+          "a": "Human approvers gate key phases, and administrators can enforce policy packs per project."
+        },
+        {
+          "q": "Does Orion support multilingual corpora?",
+          "a": "It supports multilingual ingestion and can translate sources while preserving original context."
         }
       ]
     },
@@ -53,47 +57,51 @@
       "name": "Silent Helix",
       "tagline": "Code generation & refactor engine",
       "category": ["Engineering", "Automation"],
-      "summary": "Silent Helix rewrites complex systems with repo awareness, verifiable tests, and explainable changesets you can trust.",
+      "summary": "Understands repositories end-to-end, drafts diffs, runs tests, and explains every change before it ships.",
       "heroImage": "assets/img/si-helix.svg",
       "whatItDoes": [
-        "Understands architecture context across monorepos and services",
-        "Designs change plans aligned to acceptance criteria and guardrails",
-        "Produces human-auditable diffs with rationale and upgrade notes"
+        "Learns your architecture and dependency graph for context-aware planning.",
+        "Generates and updates code with deterministic, repo-aware diffs.",
+        "Explains rationale in reviewer-friendly language with linked evidence."
       ],
       "howItWorks": [
-        "Indexes your repositories and dependency graphs for situational awareness",
-        "Drafts iterative change proposals validated by existing and generated tests",
-        "Summarizes outcomes with documentation-ready briefs"
+        "Ingests repositories and policies to set guardrails for autonomous commits.",
+        "Runs iterative change plans validated by existing and generated tests.",
+        "Produces annotated diffs, rollout guides, and documentation snippets."
       ],
       "features": [
-        "Repo-aware diffing with semantic grouping",
-        "Test-guided refactors and safety nets",
-        "Explainer summaries for reviewers",
-        "Secure isolated execution pods",
-        "Continuous improvement feedback loops"
+        "Repo-wide refactor orchestration with semantic grouping.",
+        "Test-guided execution, including sandboxed CI dry runs.",
+        "Change rationale summaries for reviewers and stakeholders.",
+        "Secure execution pods with secrets isolation.",
+        "Continuous feedback loop that learns from merged PRs."
       ],
       "specs": {
-        "language-support": "Polyglot (TypeScript, Python, Go, Rust, more)",
+        "language-support": "TypeScript, Python, Go, Rust, Java, plus extensible adapters",
         "ci-integrations": "GitHub, GitLab, Jenkins, Buildkite",
-        "compliance": "SOC2 Type II ready, configurable data retention",
-        "deployment": "Managed VPC or customer-hosted"
+        "compliance": "SOC 2 Type II controls with configurable retention",
+        "deployment": "Hosted by Silent or deployed on your infrastructure"
       },
       "faq": [
         {
-          "q": "Can Helix operate on large monorepos?",
-          "a": "Absolutely. Helix parallelizes context ingestion and maintains deterministic plans even for multi-million line estates." 
+          "q": "How does Helix stay aligned with our code standards?",
+          "a": "It uses policy packs and lint configurations pulled directly from your repos before drafting any change."
         },
         {
-          "q": "How does Helix keep humans in control?",
-          "a": "Every execution step requires policy-aligned approval gates and produces interpretable diffs before merging." 
+          "q": "Can Helix manage large monorepos?",
+          "a": "Yes. Helix shards context intelligently and coordinates multi-branch plans without losing determinism."
         },
         {
-          "q": "Does it write documentation?",
-          "a": "Yes — release notes, ADRs, and migration guides are generated alongside each change." 
+          "q": "What review visibility do engineers get?",
+          "a": "Engineers receive linked diffs, tests, and rationales so they can approve or adjust each step."
         },
         {
-          "q": "What about compliance requirements?",
-          "a": "Helix ships with auditable logs, PII scrubbing, and customizable data residency controls." 
+          "q": "Does Helix generate documentation?",
+          "a": "Documentation updates, ADRs, and release notes are produced alongside every approved change."
+        },
+        {
+          "q": "Is there support for air-gapped environments?",
+          "a": "Helix can run in air-gapped enclaves with offline artifact sync workflows."
         }
       ]
     },
@@ -102,47 +110,51 @@
       "name": "Silent Aegis",
       "tagline": "Safety & oversight layer",
       "category": ["Governance", "Safety"],
-      "summary": "Silent Aegis enforces policy-driven guardrails, scores risk in real-time, and keeps humans deeply informed of every decision.",
+      "summary": "Scores risk in real time, enforces policy packs, and surfaces transparent oversight dashboards for every agent.",
       "heroImage": "assets/img/si-aegis.svg",
       "whatItDoes": [
-        "Monitors all agent activity for compliance and emergent behaviors",
-        "Runs policy packs tuned to regulatory and organizational standards",
-        "Surfaces human-readable oversight snapshots and anomaly alerts"
+        "Monitors human and machine actions against customizable policy packs.",
+        "Runs live trace and audit tooling to surface anomalies instantly.",
+        "Generates risk reports and executive briefings with contextual evidence."
       ],
       "howItWorks": [
-        "Taps live event streams with low-latency filters",
-        "Scores interactions using governance heuristics and ML observers",
-        "Routes escalations to accountable owners with contextual evidence"
+        "Streams events from agents, APIs, and humans-in-the-loop.",
+        "Scores interactions using governance heuristics and ML observers.",
+        "Routes escalations with recommended actions and audit-ready packets."
       ],
       "features": [
-        "Policy pack marketplace with version control",
-        "Live trace explorer and anomaly heatmaps",
-        "Risk scoring dashboards with drill-downs",
-        "Autonomous containment actions with human approval",
-        "Immutable audit log exports"
+        "Policy marketplace with version control and approval workflows.",
+        "Live trace explorer with anomaly heatmaps and filters.",
+        "Risk scoring dashboards tailored to each stakeholder.",
+        "Automated containment actions gated by human approval.",
+        "Immutable audit export with chain-of-custody."
       ],
       "specs": {
-        "latency": "Sub-second signal detection",
-        "coverage": "Agents, APIs, humans-in-the-loop",
-        "reporting": "Real-time dashboards + scheduled compliance reports",
+        "latency": "Sub-second detection across distributed systems",
+        "coverage": "Agents, APIs, workflows, and manual interventions",
+        "reporting": "Real-time dashboards plus scheduled compliance briefs",
         "deployment": "Hybrid cloud with regional failover"
       },
       "faq": [
         {
-          "q": "How does Aegis integrate with existing tooling?",
-          "a": "Aegis exposes event and webhook interfaces plus native connectors for major incident platforms." 
+          "q": "Can we adapt Aegis policies to regional regulations?",
+          "a": "Absolutely. Start with Silent’s templates and layer your jurisdiction-specific rules."
         },
         {
-          "q": "Can we customize policy packs?",
-          "a": "Yes. Start with our baseline sets and tailor the guardrails to your governance requirements." 
+          "q": "How intrusive is the monitoring?",
+          "a": "Aegis watches signals, not content, and only escalates when policy thresholds are crossed."
         },
         {
-          "q": "Does Aegis remediate issues automatically?",
-          "a": "It can suggest or trigger containment depending on your risk posture, always with human authorization options." 
+          "q": "Does Aegis integrate with our incident tooling?",
+          "a": "It connects to PagerDuty, ServiceNow, Slack, and SIEM platforms for seamless response orchestration."
         },
         {
-          "q": "What visibility do executives get?",
-          "a": "Role-based dashboards align oversight to leadership, compliance, and operations stakeholders." 
+          "q": "Who benefits from Aegis dashboards?",
+          "a": "Risk teams, compliance leaders, and executives receive role-based views tuned to their responsibilities."
+        },
+        {
+          "q": "What happens if the platform detects a high-risk event?",
+          "a": "Aegis can trigger containment playbooks, require human acknowledgment, and preserve an immutable audit trail."
         }
       ]
     }

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,4 @@
+[[redirects]]
+  from = "/api/*"
+  to = "/.netlify/functions/llm"
+  status = 200

--- a/privacy.html
+++ b/privacy.html
@@ -5,17 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Privacy Policy — Silent</title>
   <meta name="description" content="Read Silent’s privacy commitments for data stewardship and governance." />
-  <link rel="canonical" href="https://silent.superintelligence/privacy.html" />
+  <link rel="canonical" href="https://rheashopp.github.io/my-website/privacy.html" />
   <link rel="icon" href="assets/icons/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Silent Privacy Policy" />
   <meta property="og:description" content="Silent’s privacy policy outlining how we handle data in responsible deployments." />
-  <meta property="og:image" content="https://silent.superintelligence/assets/img/og-cover.svg" />
+  <meta property="og:image" content="https://rheashopp.github.io/my-website/assets/img/og-cover.svg" />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://silent.superintelligence/privacy.html" />
+  <meta property="og:url" content="https://rheashopp.github.io/my-website/privacy.html" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Silent Privacy Policy" />
   <meta name="twitter:description" content="Privacy commitments for Silent deployments." />
-  <meta name="twitter:image" content="https://silent.superintelligence/assets/img/og-cover.svg" />
+  <meta name="twitter:image" content="https://rheashopp.github.io/my-website/assets/img/og-cover.svg" />
   <link rel="stylesheet" href="assets/css/style.css" />
 </head>
 <body data-page="privacy">
@@ -40,7 +40,7 @@
     <section class="section">
       <div class="container">
         <h1>Privacy Policy</h1>
-        <p><strong>Last updated:</strong> October 1, 2024</p>
+        <p><strong>Last updated:</strong> September 18, 2025</p>
         <p>Silent designs super-intelligent systems with privacy and governance as first principles. This policy outlines how we handle data when you interact with our website and services.</p>
         <h2>Information We Collect</h2>
         <p>We collect contact information you choose to share (such as your name, organization, role, and email) and limited usage metadata used to secure the platform.</p>

--- a/products/index.html
+++ b/products/index.html
@@ -3,30 +3,33 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <title>Silent Products — Super Intelligence Systems</title>
-  <meta name="description" content="Explore Silent’s suite of super intelligence systems for research, engineering, and governance teams." />
-  <link rel="canonical" href="https://silent.superintelligence/products/index.html" />
+  <title>Silent Products — Research, Engineering, Safety Systems</title>
+  <meta name="description" content="Discover the Silent SI portfolio — Orion for research, Helix for engineering, and Aegis for safety oversight." />
+  <link rel="canonical" href="https://rheashopp.github.io/my-website/products/index.html" />
   <link rel="icon" href="../assets/icons/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Silent Products" />
-  <meta property="og:description" content="Discover Silent Orion, Helix, and Aegis — future-forward systems built for responsible autonomy." />
-  <meta property="og:image" content="https://silent.superintelligence/assets/img/og-cover.svg" />
+  <meta property="og:description" content="Explore Silent Orion, Helix, and Aegis — intelligent systems with evidence-linked oversight." />
+  <meta property="og:image" content="https://rheashopp.github.io/my-website/assets/img/og-cover.svg" />
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://silent.superintelligence/products/index.html" />
+  <meta property="og:url" content="https://rheashopp.github.io/my-website/products/index.html" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Silent Products" />
-  <meta name="twitter:description" content="Explore Silent’s suite of super intelligent systems." />
-  <meta name="twitter:image" content="https://silent.superintelligence/assets/img/og-cover.svg" />
+  <meta name="twitter:description" content="Silent Orion, Helix, and Aegis deliver research, engineering, and safety capabilities." />
+  <meta name="twitter:image" content="https://rheashopp.github.io/my-website/assets/img/og-cover.svg" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <script>
     window.SILENT_CONFIG = window.SILENT_CONFIG || {};
-    window.SILENT_CONFIG.site = Object.assign({}, window.SILENT_CONFIG.site, { basePath: '..' });
+    window.SILENT_CONFIG.site = Object.assign({}, window.SILENT_CONFIG.site, {
+      basePath: '..',
+      baseUrl: 'https://rheashopp.github.io/my-website'
+    });
   </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
     "name": "Silent Products",
-    "url": "https://silent.superintelligence/products/index.html",
+    "url": "https://rheashopp.github.io/my-website/products/index.html",
     "description": "Explore Silent’s suite of super intelligence systems.",
     "about": ["Silent Orion", "Silent Helix", "Silent Aegis"]
   }

--- a/products/si-aegis.html
+++ b/products/si-aegis.html
@@ -4,35 +4,38 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Silent Aegis — Safety &amp; Oversight Layer</title>
-  <meta name="description" content="Silent Aegis enforces policy-driven guardrails, delivers risk scoring, and provides human-readable oversight." />
-  <link rel="canonical" href="https://silent.superintelligence/products/si-aegis.html" />
+  <meta name="description" content="Silent Aegis enforces policy packs, scores risk in real time, and surfaces transparent oversight." />
+  <link rel="canonical" href="https://rheashopp.github.io/my-website/products/si-aegis.html" />
   <link rel="icon" href="../assets/icons/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Silent Aegis" />
   <meta property="og:description" content="Safety and oversight layer with policy packs, traceability, and risk scoring." />
-  <meta property="og:image" content="https://silent.superintelligence/assets/img/si-aegis.svg" />
+  <meta property="og:image" content="https://rheashopp.github.io/my-website/assets/img/si-aegis.svg" />
   <meta property="og:type" content="product" />
-  <meta property="og:url" content="https://silent.superintelligence/products/si-aegis.html" />
+  <meta property="og:url" content="https://rheashopp.github.io/my-website/products/si-aegis.html" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Silent Aegis" />
   <meta name="twitter:description" content="Safety and oversight layer for disciplined autonomy." />
-  <meta name="twitter:image" content="https://silent.superintelligence/assets/img/si-aegis.svg" />
+  <meta name="twitter:image" content="https://rheashopp.github.io/my-website/assets/img/si-aegis.svg" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <script>
     window.SILENT_CONFIG = window.SILENT_CONFIG || {};
-    window.SILENT_CONFIG.site = Object.assign({}, window.SILENT_CONFIG.site, { basePath: '..' });
+    window.SILENT_CONFIG.site = Object.assign({}, window.SILENT_CONFIG.site, {
+      basePath: '..',
+      baseUrl: 'https://rheashopp.github.io/my-website'
+    });
   </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "Product",
     "name": "Silent Aegis",
-    "image": "https://silent.superintelligence/assets/img/si-aegis.svg",
+    "image": "https://rheashopp.github.io/my-website/assets/img/si-aegis.svg",
     "description": "Safety and oversight layer that enforces policy-driven guardrails and real-time risk scoring.",
     "brand": {
       "@type": "Brand",
       "name": "Silent"
     },
-    "url": "https://silent.superintelligence/products/si-aegis.html"
+    "url": "https://rheashopp.github.io/my-website/products/si-aegis.html"
   }
   </script>
 </head>
@@ -61,7 +64,7 @@
           <div class="hero-meta" data-product-breadcrumbs></div>
           <h1 data-product-name>Silent Aegis</h1>
           <p data-product-tagline>Safety &amp; oversight layer.</p>
-          <p data-product-summary>Aegis enforces guardrails and keeps oversight clear.</p>
+          <p data-product-summary>Silent Aegis enforces guardrails, surfaces risk, and keeps oversight clear.</p>
           <img data-product-image src="../assets/img/si-aegis.svg" alt="Silent Aegis interface visualization" loading="lazy" />
         </div>
         <aside class="product-sticky">

--- a/products/si-helix.html
+++ b/products/si-helix.html
@@ -4,35 +4,38 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Silent Helix — Code Generation &amp; Refactor Engine</title>
-  <meta name="description" content="Silent Helix delivers repo-aware diffs, test-guided refactors, and explainer summaries for engineering teams." />
-  <link rel="canonical" href="https://silent.superintelligence/products/si-helix.html" />
+  <meta name="description" content="Silent Helix understands your repos, drafts diffs, runs tests, and explains every change." />
+  <link rel="canonical" href="https://rheashopp.github.io/my-website/products/si-helix.html" />
   <link rel="icon" href="../assets/icons/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Silent Helix" />
   <meta property="og:description" content="Code generation and refactor engine aligned to your engineering rituals." />
-  <meta property="og:image" content="https://silent.superintelligence/assets/img/si-helix.svg" />
+  <meta property="og:image" content="https://rheashopp.github.io/my-website/assets/img/si-helix.svg" />
   <meta property="og:type" content="product" />
-  <meta property="og:url" content="https://silent.superintelligence/products/si-helix.html" />
+  <meta property="og:url" content="https://rheashopp.github.io/my-website/products/si-helix.html" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Silent Helix" />
   <meta name="twitter:description" content="Repo-aware generation and refactors with explainable diffs." />
-  <meta name="twitter:image" content="https://silent.superintelligence/assets/img/si-helix.svg" />
+  <meta name="twitter:image" content="https://rheashopp.github.io/my-website/assets/img/si-helix.svg" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <script>
     window.SILENT_CONFIG = window.SILENT_CONFIG || {};
-    window.SILENT_CONFIG.site = Object.assign({}, window.SILENT_CONFIG.site, { basePath: '..' });
+    window.SILENT_CONFIG.site = Object.assign({}, window.SILENT_CONFIG.site, {
+      basePath: '..',
+      baseUrl: 'https://rheashopp.github.io/my-website'
+    });
   </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "Product",
     "name": "Silent Helix",
-    "image": "https://silent.superintelligence/assets/img/si-helix.svg",
+    "image": "https://rheashopp.github.io/my-website/assets/img/si-helix.svg",
     "description": "Code generation and refactor engine that produces repo-aware diffs, guided tests, and explainable summaries.",
     "brand": {
       "@type": "Brand",
       "name": "Silent"
     },
-    "url": "https://silent.superintelligence/products/si-helix.html"
+    "url": "https://rheashopp.github.io/my-website/products/si-helix.html"
   }
   </script>
 </head>
@@ -61,7 +64,7 @@
           <div class="hero-meta" data-product-breadcrumbs></div>
           <h1 data-product-name>Silent Helix</h1>
           <p data-product-tagline>Code generation &amp; refactor engine.</p>
-          <p data-product-summary>Helix builds repo-aware diffs with explainable context.</p>
+          <p data-product-summary>Silent Helix drafts repo-aware diffs and explains every change before it merges.</p>
           <img data-product-image src="../assets/img/si-helix.svg" alt="Silent Helix interface visualization" loading="lazy" />
         </div>
         <aside class="product-sticky">

--- a/products/si-orion.html
+++ b/products/si-orion.html
@@ -4,35 +4,38 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Silent Orion — Autonomous Research Co-pilot</title>
-  <meta name="description" content="Silent Orion synthesizes evidence, plans investigations, and keeps provenance transparent for high-velocity research teams." />
-  <link rel="canonical" href="https://silent.superintelligence/products/si-orion.html" />
+  <meta name="description" content="Silent Orion plans research, activates approved tools, and keeps every insight linked to evidence." />
+  <link rel="canonical" href="https://rheashopp.github.io/my-website/products/si-orion.html" />
   <link rel="icon" href="../assets/icons/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Silent Orion" />
-  <meta property="og:description" content="Autonomous research co-pilot delivering sourced intelligence and accountable planning." />
-  <meta property="og:image" content="https://silent.superintelligence/assets/img/si-orion.svg" />
+  <meta property="og:description" content="Autonomous research co-pilot delivering evidence-linked synthesis and accountable planning." />
+  <meta property="og:image" content="https://rheashopp.github.io/my-website/assets/img/si-orion.svg" />
   <meta property="og:type" content="product" />
-  <meta property="og:url" content="https://silent.superintelligence/products/si-orion.html" />
+  <meta property="og:url" content="https://rheashopp.github.io/my-website/products/si-orion.html" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Silent Orion" />
   <meta name="twitter:description" content="Autonomous research co-pilot built for evidence-driven teams." />
-  <meta name="twitter:image" content="https://silent.superintelligence/assets/img/si-orion.svg" />
+  <meta name="twitter:image" content="https://rheashopp.github.io/my-website/assets/img/si-orion.svg" />
   <link rel="stylesheet" href="../assets/css/style.css" />
   <script>
     window.SILENT_CONFIG = window.SILENT_CONFIG || {};
-    window.SILENT_CONFIG.site = Object.assign({}, window.SILENT_CONFIG.site, { basePath: '..' });
+    window.SILENT_CONFIG.site = Object.assign({}, window.SILENT_CONFIG.site, {
+      basePath: '..',
+      baseUrl: 'https://rheashopp.github.io/my-website'
+    });
   </script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
     "@type": "Product",
     "name": "Silent Orion",
-    "image": "https://silent.superintelligence/assets/img/si-orion.svg",
+    "image": "https://rheashopp.github.io/my-website/assets/img/si-orion.svg",
     "description": "Autonomous research co-pilot that synthesizes evidence with provenance and transparent planning.",
     "brand": {
       "@type": "Brand",
       "name": "Silent"
     },
-    "url": "https://silent.superintelligence/products/si-orion.html"
+    "url": "https://rheashopp.github.io/my-website/products/si-orion.html"
   }
   </script>
 </head>
@@ -61,7 +64,7 @@
           <div class="hero-meta" data-product-breadcrumbs></div>
           <h1 data-product-name>Silent Orion</h1>
           <p data-product-tagline>Autonomous research co-pilot.</p>
-          <p data-product-summary>Orion synthesizes evidence and keeps provenance visible.</p>
+          <p data-product-summary>Silent Orion links every recommendation to verifiable evidence trails.</p>
           <img data-product-image src="../assets/img/si-orion.svg" alt="Silent Orion interface visualization" loading="lazy" />
         </div>
         <aside class="product-sticky">

--- a/research.html
+++ b/research.html
@@ -5,17 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Silent Research — Benchmarks, Methodology, Safety</title>
   <meta name="description" content="Dive into Silent’s research roadmap, including benchmarks, methodology, limitations, and safety pillars." />
-  <link rel="canonical" href="https://silent.superintelligence/research.html" />
+  <link rel="canonical" href="https://rheashopp.github.io/my-website/research.html" />
   <link rel="icon" href="assets/icons/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Silent Research" />
   <meta property="og:description" content="Review Silent’s research program, benchmarks, methodology, and safety guardrails." />
-  <meta property="og:image" content="https://silent.superintelligence/assets/img/og-cover.svg" />
+  <meta property="og:image" content="https://rheashopp.github.io/my-website/assets/img/og-cover.svg" />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://silent.superintelligence/research.html" />
+  <meta property="og:url" content="https://rheashopp.github.io/my-website/research.html" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Silent Research" />
   <meta name="twitter:description" content="Benchmarks, methodology, limitations, and safety principles for Silent." />
-  <meta name="twitter:image" content="https://silent.superintelligence/assets/img/og-cover.svg" />
+  <meta name="twitter:image" content="https://rheashopp.github.io/my-website/assets/img/og-cover.svg" />
   <link rel="stylesheet" href="assets/css/style.css" />
 </head>
 <body data-page="research">

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://silent.superintelligence/sitemap.xml
+Sitemap: https://rheashopp.github.io/my-website/sitemap.xml

--- a/serverless/README.md
+++ b/serverless/README.md
@@ -20,17 +20,17 @@ The `messages` array mirrors OpenAI/Gemini chat formats. `sessionId` is forwarde
   - `PROVIDER` — `openai` or `gemini` (defaults to `openai`)
   - `OPENAI_API_KEY` and optional `OPENAI_MODEL` (defaults to `gpt-4o-mini`)
   - `GEMINI_API_KEY` and optional `GEMINI_MODEL` (defaults to `gemini-2.5-flash`)
-- Add a redirect in `netlify.toml`:
+- Add a redirect in `netlify.toml` so `/api/*` points to the function:
 
   ```toml
   [[redirects]]
-  from = "/api/llm"
-  to = "/.netlify/functions/llm"
-  status = 200
-  force = true
+    from = "/api/*"
+    to = "/.netlify/functions/llm"
+    status = 200
   ```
 
-- Deploy with `netlify deploy` or the Netlify UI. Keys are configured under **Site settings → Environment variables**.
+- Deploy with `netlify deploy` or the Netlify UI. Configure env vars under **Site settings → Environment variables**.
+- The function only allows CORS requests from `https://rheashopp.github.io` to match the GitHub Pages deployment.
 
 ## Cloudflare Workers
 
@@ -46,11 +46,11 @@ The `messages` array mirrors OpenAI/Gemini chat formats. `sessionId` is forwarde
   main = "serverless/cloudflare/worker.js"
 
   routes = [
-    { pattern = "silent.superintelligence/api/llm", zone_name = "silent.superintelligence" }
+    { pattern = "rheashopp.github.io/api/llm", custom_domain = true }
   ]
   ```
 
-Cloudflare deploys with `wrangler publish`. Attach the same environment variables under **Workers → Settings → Variables**.
+Deploy with `wrangler publish` and attach the same environment variables under **Workers → Settings → Variables**. The worker also restricts CORS responses to `https://rheashopp.github.io`.
 
 ## CORS & security
 

--- a/serverless/cloudflare/worker.js
+++ b/serverless/cloudflare/worker.js
@@ -1,8 +1,8 @@
 export default {
   async fetch(request, env) {
-    const origin = request.headers.get('Origin') || '*';
+    const allowedOrigin = 'https://rheashopp.github.io';
     const corsHeaders = {
-      'Access-Control-Allow-Origin': origin,
+      'Access-Control-Allow-Origin': allowedOrigin,
       'Access-Control-Allow-Methods': 'POST, OPTIONS',
       'Access-Control-Allow-Headers': 'Content-Type, Accept, X-Requested-With',
       Vary: 'Origin',

--- a/serverless/netlify/functions/llm.js
+++ b/serverless/netlify/functions/llm.js
@@ -2,16 +2,16 @@ const DEFAULT_PROVIDER = (process.env.PROVIDER || 'openai').toLowerCase();
 const OPENAI_MODEL = process.env.OPENAI_MODEL || 'gpt-4o-mini';
 const GEMINI_MODEL = process.env.GEMINI_MODEL || 'gemini-2.5-flash';
 
+const ALLOWED_ORIGIN = 'https://rheashopp.github.io';
 const allowedHeaders = {
   'Access-Control-Allow-Headers': 'Content-Type, Accept, X-Requested-With',
   'Access-Control-Allow-Methods': 'POST, OPTIONS',
 };
 
 exports.handler = async function handler(event) {
-  const origin = event.headers.origin || '*';
   const corsHeaders = {
     ...allowedHeaders,
-    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
     Vary: 'Origin',
   };
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://silent.superintelligence/index.html</loc>
+    <loc>https://rheashopp.github.io/my-website/index.html</loc>
   </url>
   <url>
-    <loc>https://silent.superintelligence/about.html</loc>
+    <loc>https://rheashopp.github.io/my-website/about.html</loc>
   </url>
   <url>
-    <loc>https://silent.superintelligence/contact.html</loc>
+    <loc>https://rheashopp.github.io/my-website/research.html</loc>
   </url>
   <url>
-    <loc>https://silent.superintelligence/privacy.html</loc>
+    <loc>https://rheashopp.github.io/my-website/products/index.html</loc>
   </url>
   <url>
-    <loc>https://silent.superintelligence/terms.html</loc>
+    <loc>https://rheashopp.github.io/my-website/products/si-orion.html</loc>
   </url>
   <url>
-    <loc>https://silent.superintelligence/research.html</loc>
+    <loc>https://rheashopp.github.io/my-website/products/si-helix.html</loc>
   </url>
   <url>
-    <loc>https://silent.superintelligence/chat.html</loc>
+    <loc>https://rheashopp.github.io/my-website/products/si-aegis.html</loc>
   </url>
   <url>
-    <loc>https://silent.superintelligence/products/index.html</loc>
+    <loc>https://rheashopp.github.io/my-website/contact.html</loc>
   </url>
   <url>
-    <loc>https://silent.superintelligence/products/si-orion.html</loc>
+    <loc>https://rheashopp.github.io/my-website/chat.html</loc>
   </url>
   <url>
-    <loc>https://silent.superintelligence/products/si-helix.html</loc>
+    <loc>https://rheashopp.github.io/my-website/privacy.html</loc>
   </url>
   <url>
-    <loc>https://silent.superintelligence/products/si-aegis.html</loc>
+    <loc>https://rheashopp.github.io/my-website/terms.html</loc>
   </url>
   <url>
-    <loc>https://silent.superintelligence/404.html</loc>
+    <loc>https://rheashopp.github.io/my-website/404.html</loc>
   </url>
 </urlset>

--- a/terms.html
+++ b/terms.html
@@ -5,17 +5,17 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Terms of Use — Silent</title>
   <meta name="description" content="Read Silent’s terms of use governing the early access program." />
-  <link rel="canonical" href="https://silent.superintelligence/terms.html" />
+  <link rel="canonical" href="https://rheashopp.github.io/my-website/terms.html" />
   <link rel="icon" href="assets/icons/favicon.svg" type="image/svg+xml" />
   <meta property="og:title" content="Silent Terms of Use" />
   <meta property="og:description" content="Terms governing Silent’s super intelligence platform and early access." />
-  <meta property="og:image" content="https://silent.superintelligence/assets/img/og-cover.svg" />
+  <meta property="og:image" content="https://rheashopp.github.io/my-website/assets/img/og-cover.svg" />
   <meta property="og:type" content="article" />
-  <meta property="og:url" content="https://silent.superintelligence/terms.html" />
+  <meta property="og:url" content="https://rheashopp.github.io/my-website/terms.html" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="Silent Terms of Use" />
   <meta name="twitter:description" content="Understand the responsibilities and commitments for using Silent." />
-  <meta name="twitter:image" content="https://silent.superintelligence/assets/img/og-cover.svg" />
+  <meta name="twitter:image" content="https://rheashopp.github.io/my-website/assets/img/og-cover.svg" />
   <link rel="stylesheet" href="assets/css/style.css" />
 </head>
 <body data-page="terms">
@@ -40,7 +40,7 @@
     <section class="section">
       <div class="container">
         <h1>Terms of Use</h1>
-        <p><strong>Last updated:</strong> October 1, 2024</p>
+        <p><strong>Last updated:</strong> September 18, 2025</p>
         <p>These terms govern Silent’s early access program and associated services.</p>
         <h2>Eligibility</h2>
         <p>Participants must be authorized representatives of their organization and commit to using Silent in accordance with applicable laws and internal governance policies.</p>


### PR DESCRIPTION
## Summary
- Build out product catalog and detail pages, research/about/chat/contact/privacy/terms content shells, and 404 copy aligned to the GitHub Pages deployment.
- Wire data/products.json driven content, accessibility-friendly contact form with Formspree placeholder, and refreshed sitemap/robots metadata.
- Add optional voice overlay (CSS/JS plus lazy loader), product artwork placeholders, and document Netlify/Cloudflare `/api/llm` proxies with redirects.

## Files
- 404.html
- README.md
- about.html
- assets/css/voice.css
- assets/img/og-cover.svg
- assets/img/si-aegis.svg
- assets/img/si-helix.svg
- assets/img/si-orion.svg
- assets/js/main.js
- assets/js/voice.js
- assets/js/vendor/webaudio-viz.js
- chat.html
- contact.html
- data/products.json
- netlify.toml
- privacy.html
- products/index.html
- products/si-aegis.html
- products/si-helix.html
- products/si-orion.html
- research.html
- robots.txt
- serverless/README.md
- serverless/cloudflare/worker.js
- serverless/netlify/functions/llm.js
- sitemap.xml
- terms.html

## Voice overlay
Add this configuration after including `assets/js/main.js` on any page where the orb should appear:
```html
<script>
  window.SILENT_CONFIG = window.SILENT_CONFIG || {};
  window.SILENT_CONFIG.voice = { enabled: true, provider: 'demo', ttsVoiceName: null };
</script>
```
Set `provider` to `openai` or `gemini` (with serverless keys configured) to proxy LLM calls; the overlay auto-falls back to text input when speech recognition is missing.

## Serverless deployment
- **Netlify**
  1. Deploy `serverless/netlify/functions/llm.js` and keep the provided `netlify.toml` redirect so `/api/*` hits the function.
  2. In Site settings → Environment variables, set `PROVIDER`, `OPENAI_API_KEY`/`OPENAI_MODEL`, and/or `GEMINI_API_KEY`/`GEMINI_MODEL`.
  3. Ensure CORS remains scoped to `https://rheashopp.github.io`.
- **Cloudflare Workers**
  1. Publish `serverless/cloudflare/worker.js` with `wrangler publish`.
  2. Configure secrets for `PROVIDER`, `OPENAI_API_KEY`/`OPENAI_MODEL`, and `GEMINI_API_KEY`/`GEMINI_MODEL`.
  3. Attach a route such as `rheashopp.github.io/api/llm` and keep the allowed origin at `https://rheashopp.github.io`.

## Acceptance
- ✅ Homepage markup and core stylesheet untouched
- ✅ Products catalog and detail pages hydrate from JSON with search and filters
- ✅ Contact form validates inline and posts to the Formspree placeholder
- ✅ Voice overlay disabled by default and functional when enabled via SILENT_CONFIG
- ✅ `/api/llm` proxied via Netlify/Cloudflare with no client-side keys
- ✅ All links/assets use GitHub Pages-safe relative paths
- ✅ Binary assets avoided (SVG placeholders only)
- ✅ Lighthouse-ready metadata via robots.txt, sitemap.xml, and per-page heads


------
https://chatgpt.com/codex/tasks/task_e_68cc2ccd3df0832889b0d8a4e2fc2096